### PR TITLE
Fixes for localized strings

### DIFF
--- a/data/input_display.lua
+++ b/data/input_display.lua
@@ -22,7 +22,7 @@ local select_input = {
 
 local control_select_input = {
     type = "custom-input",
-    key_sequence = "CONTROL+mouse-button-1",
+    key_sequence = "CONTROL + mouse-button-1",
     name = prefix .. "-control-click"
 }
 

--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -13,11 +13,12 @@ compaktcircuit-display=Display component
 compaktcircuit-input=Input component
 
 [entity-description]
-compaktcircuit-processor=Compact processor, click to edit
-compaktcircuit-internal_iopoint=Input/Output pole - Communicate with external input/output pole
+compaktcircuit-processor=A processor device with a computing power of dozens of internal basic combinators.\n тАв __CONTROL__compaktcircuit-click__ to edit.\n тАв __CONTROL__compaktcircuit-control-click__ to open settings.
+compaktcircuit-processor_1x1=A smaller processor device with a computing power of multiple internal basic combinators.\n тАв __CONTROL__compaktcircuit-click__ to edit.\n тАв __CONTROL__compaktcircuit-control-click__ to open settings.
+compaktcircuit-internal_iopoint=Input/Output pole - Communicate with external input/output pole.
 compaktcircuit-internal_connector=Internal connector. Used to connect circuit wire on a long distance.
-compaktcircuit-display=Multi usage component to display number / text / sprite or use a meta combinator
-compaktcircuit-input=Component that define an input component in the property form of the processor
+compaktcircuit-display=Multi usage component to display number / text / sprite or use a meta combinator.
+compaktcircuit-input=Component that define an input component in the property form of the processor.
 
 [mod-setting-name]
 compaktcircuit-mine_processor_as_tags=Mine processor as tag entity
@@ -231,7 +232,7 @@ auto-save-tooltip=Save automatically the properties after a modification
 toggle_count=Count of toggle
 toggle_count-tooltip=Each toggle set/reset a bit in the result, lowest bit first
 toggle-tooltips=Tooltips on each toggle
-dropdown-tooltips-tooltip=Add a tooltip for each toggle, one per line
+toggle-tooltips-tooltip=Add a tooltip for each toggle, one per line
 
 [virtual-signal-name]
 compaktcircuit-hide=Hide component

--- a/scripts/input.lua
+++ b/scripts/input.lua
@@ -223,7 +223,7 @@ function input.add_properties(type, ptable, props)
         field = ptable.add {
             type = "text-box",
             name = "input-dropdown-labels",
-            tooltip = { np("dropdown-tooltips-tooltip") },
+            tooltip = { np("dropdown-labels-tooltip") },
             text = props.labels
         }
         field.style.height = 100


### PR DESCRIPTION
Port of changes in my original fork: https://gitlab.com/Hares-Lab/factorio-mods/compaktcircuit/-/merge_requests/1

### Bug Fixes:
 - Hotkey for open processor settings now has proper default value & description [Discussion🔗](https://mods.factorio.com/mod/compaktcircuit/discussion/656e5aa2b98969910940dd69)
 - ~~Fixed tooltip for Settings Input / Toggle / Tooltip [Discussion🔗](https://mods.factorio.com/mod/compaktcircuit/discussion/65760888c53583b40041f0c6)~~ Already fixed in *main*
 - Fixed tooltip for Settings Input / Dropdown / Choices
 - Processor entity descriptions now refer to the configured hotkeys
 - Mini-processor entity now has description

### Changes:
 - Changed description on processor entities, they now explain what they do