### PR TITLE
Raise the destroy event when removing entities

### DIFF
--- a/scripts/tools.lua
+++ b/scripts/tools.lua
@@ -725,7 +725,7 @@ function tools.destroy_entities(master, entity_names)
         },
 		name = entity_names
 	}
-    for _, e in pairs(entities) do if e.valid then e.destroy() end end
+    for _, e in pairs(entities) do if e.valid then e.destroy({raise_destroy = true }) end end
 end
 
 


### PR DESCRIPTION
When deleting a processor in packed mode, the entities it manages are also destroyed. E.g. the filter combinator mod
(https://mods.factorio.com/mod/silent-filter-combinator) maintains a set of "hidden" entities behind the packed combinator it registers with compact circuits. So when the packed filter combinator is destroyed, it leaves all of those hidden entities behind because it never gets notified that the main entity (which was registered with cc) was destroyed.

One could argue that this is a bug with the filter combinator and that it should register all its hidden combinators with cc as well, but the easier way to solve this is to raise the "destroyed" event to allow a combinator that was removed by cc to react on it and clean out its own state.

This is the source of the issue described here:
https://mods.factorio.com/mod/silent-filter-combinator/discussion/6619efa09f1c8f745810d02f (the blue lights left are the activity lights of the hidden combinators that were not deleted when the main entity was deleted.