### PR TITLE
Add compatibility with factorissimo 3

### DIFF
--- a/data/data.lua
+++ b/data/data.lua
@@ -553,3 +553,8 @@ data:extend { internal_connector, internal_connector_item }
 
 ---------------------------
 combinators.create_internals()
+
+data:extend {{
+    type = "custom-event",
+    name = "on_script_setup_blueprint"
+}}

--- a/scripts/processor.lua
+++ b/scripts/processor.lua
@@ -584,6 +584,14 @@ tools.on_event(defines.events.on_player_setup_blueprint,
         if bp then register_mapping(bp, mapping, player.surface) end
     end)
 
+script.on_event("on_script_setup_blueprint",
+    ---@param e EventData.on_player_setup_blueprint
+    function(e)
+        ---@type table<integer, LuaEntity>
+        local mapping = e.mapping
+        register_mapping(e.stack, mapping, e.surface)
+    end)
+    
 tools.on_event(defines.events.on_gui_closed, on_register_bp)
 
 ---@param ev EventData.on_entity_cloned


### PR DESCRIPTION
This PR implements an event handler for factorissimo's custom on_script_setup_blueprint event.
It uses the new custom events system added in 2.0
This allows compact circuits to properly setup entity tags.