### PR TITLE
Prevent crash when opening interface without connected red or green circuit wires

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.0.19
+Date: 05. 04. 2025.
+  Bugfixes:
+    - Prevent crash when opening interface without connected red or green circuit wires
+    - Made `display` function handle `nil` or empty signal tables safely
+---------------------------------------------------------------------------------------------------
 Version: 2.0.18
 Date: 28. 03. 2025.
   Changes:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "compaktcircuit",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "title": "Compakt circuits",
   "author": "Telkine2018",
   "contact": "",

--- a/scripts/comm.lua
+++ b/scripts/comm.lua
@@ -704,7 +704,8 @@ function comm.update(player)
     ---@param signals Signal[]?
     ---@param button_style string
     local function display(signals, button_style)
-        if not signals or #signals == 0 then return end
+        signals = signals or {}
+        if #signals == 0 then return end
 
         local filter_map
         if config.apply_filters and config.filters and #config.filters > 0 then
@@ -802,6 +803,7 @@ function comm.update(player)
                     local green_signals = cb.get_circuit_network(defines.wire_connector_id.circuit_green)
                     ---@cast green_signals -nil
                     display(green_signals.signals, green_button)
+
 
                     signal_panel.add { type = "line", direction = "horizontal" }
                     signal_panel.style.horizontally_stretchable = true

--- a/scripts/comm.lua
+++ b/scripts/comm.lua
@@ -804,7 +804,6 @@ function comm.update(player)
                     ---@cast green_signals -nil
                     display(green_signals.signals, green_button)
 
-
                     signal_panel.add { type = "line", direction = "horizontal" }
                     signal_panel.style.horizontally_stretchable = true
                 end


### PR DESCRIPTION
Prevent crash when opening interface without connected red or green circuit wires
Made `display` function handle `nil` or empty signal tables safely