### PR TITLE
Allow "Recipe Combinator" - assembling-machine

### DIFF
--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -1395,7 +1395,7 @@ local forbidden_prototypes = {
 
     ["container"] = true,
     ["logistic-container"] = true,
-    ["assembling-machine"] = true,
+    ["assembling-machine"] = false, -- Recipe Combinator is implemented as an assembling machine - https://mods.factorio.com/mod/lo-recipe-combinator - but it tested to work fine if allow it!
     ["boiler"] = true,
     ["transport-belt"] = true,
     ["underground-belt"] = true,


### PR DESCRIPTION
LordOdin's Recipe Combinator is implemented as an assembling machine - https://mods.factorio.com/mod/lo-recipe-combinator - but it tested to work fine if allow it!

The mod already compartible, but this line stops player from placing the combinator inside CC. Please allow it.