### PR TITLE
Handle Factorio 2.0 "My library" blueprints

### DIFF
--- a/scripts/processor.lua
+++ b/scripts/processor.lua
@@ -752,8 +752,19 @@ tools.on_event(defines.events.on_player_setup_blueprint,
         local player = game.players[e.player_index]
         ---@type table<integer, LuaEntity>
         local mapping = e.mapping.get()
-        local bp = get_bp_to_setup(player)
-        if bp then register_mapping(bp, mapping, player.surface) end
+
+        -- e.stack: inventory/cursor blueprint; e.record: library blueprint reselect
+        ---@type LuaItemStack | LuaRecord | nil
+        local bp
+        if e.stack then
+            bp = e.stack
+        elseif e.record then
+            bp = e.record
+        else
+            bp = get_bp_to_setup(player)
+        end
+
+        if bp then register_mapping(bp --[[@as LuaItemStack]], mapping, e.surface) end
     end)
 
 script.on_event("on_script_setup_blueprint",


### PR DESCRIPTION
Figured this out while working on #58.

This should finally clear up ["Reselecting blueprint content deletes the compakt circuit information"](https://mods.factorio.com/mod/compaktcircuit/discussion/67b529ee33c6df19f2b7070b) (and several other reports.) I tested it, and modifications seem to be correctly applying to "My library"-shelf blueprints (as well as the savegame's shelf.)

I also tested from both packed and unpacked processors; but wasn't sure how else to excercise, lol.