### PR TITLE
Switch fully to "remote view", fully remove teleportation

### DIFF
--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -96,7 +96,6 @@ models=Open models dialog
 [compaktcircuit-button]
 save=Save
 edit=Edit
-exit_editor=Exit editor
 models=Models
 add_iopole=Add input/output pole
 save_and_close=Save & Close

--- a/locale/ru/base.cfg
+++ b/locale/ru/base.cfg
@@ -87,7 +87,6 @@ models=Открыть диалог моделей
 [compaktcircuit-button]
 save=Сохранить
 edit=Редактировать
-exit_editor=Выйти из редактора
 models=Модели
 add_iopole=Добавить ввод/вывод
 save_and_close=Сохранить и закрыть

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -242,16 +242,14 @@ end
 ---@param processor LuaEntity
 function editor.edit_selected(player, processor)
     if storage.last_click and storage.last_click > game.tick - 120 then
-        log("[compaktcircuit debug] edit_selected: ignored bounce click player=" .. player.index)
+        debug("edit_selected: ignored bounce click player=" .. player.index)
         return
     end
     storage.last_click = game.tick
 
     local blocked_reason = get_processor_entry_block_reason(player)
     if blocked_reason then
-        log("[compaktcircuit debug] edit_selected: blocked unsafe entry player=" .. player.index ..
-            " controller=" .. tostring(player.controller_type) ..
-            " physical_controller=" .. tostring(player.physical_controller_type) ..
+        debug("edit_selected: blocked unsafe entry player=" .. player.index ..
             " physical_surface=" .. tostring(player.physical_surface_index) ..
             " reason=" .. blocked_reason)
         player.print("CompaktCircuits: unsafe processor entry blocked from " ..
@@ -261,7 +259,7 @@ function editor.edit_selected(player, processor)
     end
 
     if not processor or not processor.valid then
-        log("[compaktcircuit debug] edit_selected: invalid processor player=" .. player.index)
+        debug("edit_selected: invalid processor player=" .. player.index)
         return
     end
 
@@ -287,7 +285,7 @@ function editor.edit_selected(player, processor)
     procinfo.physical_controller_type = player.physical_controller_type
     procinfo.physical_position = player.physical_position
 
-    log("[compaktcircuit debug] edit_selected: enter remote player=" .. player.index ..
+    debug("edit_selected: enter remote player=" .. player.index ..
         " processor=" .. tostring(processor.unit_number) ..
         " origin_surface=" .. tostring(procinfo.origin_surface_name) ..
         " origin_controller=" .. tostring(procinfo.origin_controller_type) ..
@@ -322,7 +320,7 @@ local function restore_player_controller(procinfo, player)
         ret_surface_position = { x = 0, y = 0 }
     end
 
-    log("[compaktcircuit debug] restore_player_controller: player=" .. player.index ..
+    debug("restore_player_controller: player=" .. player.index ..
         " return_controller=" .. tostring(ret_controller_type) ..
         " return_surface=" .. tostring(ret_surface_name) ..
         " return_pos=" .. tostring(ret_surface_position.x) .. "," .. tostring(ret_surface_position.y))
@@ -337,14 +335,14 @@ local function restore_player_controller(procinfo, player)
                     surface = character.surface
                 }
             end
-            log("[compaktcircuit debug] restore_player_controller: restore character controller player=" .. player.index)
+            debug("restore_player_controller: restore character controller player=" .. player.index)
             player.set_controller {
                 type = defines.controllers.character,
                 character = character
             }
         end
     elseif ret_controller_type == defines.controllers.god then
-        log("[compaktcircuit debug] restore_player_controller: teleport return player=" .. player.index)
+        debug("restore_player_controller: teleport return player=" .. player.index)
         player.teleport(ret_surface_position, ret_surface_name)
         local surface = game.surfaces[ret_surface_name]
         local platform = surface.platform
@@ -353,7 +351,7 @@ local function restore_player_controller(procinfo, player)
         end
     else
         if procinfo.physical_controller_type then
-            log("[compaktcircuit debug] restore_player_controller: restore physical player=" .. player.index ..
+            debug("restore_player_controller: restore physical player=" .. player.index ..
                 " surface=" .. tostring(procinfo.physical_surface_index))
             player.teleport(procinfo.physical_position, procinfo.physical_surface_index, false, false)
             local surface = game.surfaces[procinfo.physical_surface_index]
@@ -362,7 +360,7 @@ local function restore_player_controller(procinfo, player)
                 player.enter_space_platform(platform)
             end
         end
-        log("[compaktcircuit debug] restore_player_controller: set_controller return player=" .. player.index)
+        debug("restore_player_controller: set_controller return player=" .. player.index)
         player.set_controller {
             type = ret_controller_type,
             position = ret_surface_position,
@@ -379,7 +377,7 @@ function editor.restore_surface_list(player, context)
     local vars = tools.get_vars(player)
     if vars.show_surface_list_before_editor ~= nil then
         player.game_view_settings.show_surface_list = vars.show_surface_list_before_editor
-        log("[compaktcircuit debug] " .. context .. ": restore surface list player=" .. player.index ..
+        debug(context .. ": restore surface list player=" .. player.index ..
             " value=" .. tostring(vars.show_surface_list_before_editor))
         vars.show_surface_list_before_editor = nil
     end
@@ -394,7 +392,7 @@ function editor.hide_surface_list(player, context)
     end
     if player.game_view_settings.show_surface_list then
         player.game_view_settings.show_surface_list = false
-        log("[compaktcircuit debug] " .. context .. ": hide surface list player=" .. player.index)
+        debug(context .. ": hide surface list player=" .. player.index)
     end
 end
 
@@ -1069,7 +1067,7 @@ local function on_player_changed_surface(e)
     local is_standard_exit = vars.is_standard_exit
     vars.is_standard_exit = false
 
-    log("[compaktcircuit debug] on_player_changed_surface: player=" .. e.player_index ..
+    debug("on_player_changed_surface: player=" .. e.player_index ..
         " from_surface_index=" .. tostring(e.surface_index) ..
         " current_surface=" .. tostring(player.surface.name) ..
         " has_procinfo=" .. tostring(procinfo ~= nil) ..
@@ -1112,7 +1110,7 @@ local function on_player_changed_surface(e)
     -- Exiting surface
     if procinfo and procinfo.surface and procinfo.surface.valid and
         procinfo.surface.index == e.surface_index then
-        log("[compaktcircuit debug] on_player_changed_surface: leaving editor surface player=" .. e.player_index ..
+        debug("on_player_changed_surface: leaving editor surface player=" .. e.player_index ..
             " surface=" .. tostring(procinfo.surface.name) ..
             " packed=" .. tostring(procinfo.is_packed))
         finish_processor_exit(procinfo, is_standard_exit, "on_player_changed_surface")
@@ -1121,7 +1119,7 @@ local function on_player_changed_surface(e)
     local surface_name = player.surface.name
     procinfo = storage.surface_map[surface_name]
     if procinfo then
-        log("[compaktcircuit debug] on_player_changed_surface: entering editor surface player=" .. e.player_index ..
+        debug("on_player_changed_surface: entering editor surface player=" .. e.player_index ..
             " surface=" .. tostring(surface_name) ..
             " processor=" .. tostring(procinfo.processor and procinfo.processor.name))
         editor.hide_surface_list(player, "on_player_changed_surface")
@@ -1148,7 +1146,7 @@ local function on_player_controller_changed(e)
     if not procinfo or not procinfo.surface or not procinfo.surface.valid then return end
     if player.surface ~= procinfo.surface then return end
 
-    log("[compaktcircuit debug] on_player_controller_changed: restoring player=" .. e.player_index ..
+    debug("on_player_controller_changed: restoring player=" .. e.player_index ..
         " old_controller=" .. (controller_names[e.old_type] or tostring(e.old_type)) ..
         " new_controller=" .. (controller_names[player.controller_type] or tostring(player.controller_type)) ..
         " surface=" .. tostring(player.surface.name))

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -379,6 +379,7 @@ local function on_gui_checked_state_changed(e)
 
     local vars = get_vars(player)
     local procinfo = vars.procinfo
+    if not procinfo then return end
     local new_packed = e.element.state
     editor.set_packed(procinfo, new_packed, player)
 end
@@ -839,6 +840,7 @@ local function on_gui_selection_state_changed(e)
 
     ---@type ProcInfo
     local procinfo = vars.procinfo
+    if not procinfo then return end
     local iopole_info = get_iopoint_info(procinfo, iopole)
 
     if name == prefix .. ".iopole_index" then
@@ -893,13 +895,15 @@ local function on_gui_text_changed(e)
         local iopole = vars.iopole
         if not iopole or not iopole.valid then return end
         local procinfo = vars.procinfo
+        if not procinfo then return end
 
         local iopoint_info = get_iopoint_info(procinfo, iopole)
         if not iopoint_info then return end
         iopoint_info.label = e.element.text
         build.update_io_text(iopoint_info)
     elseif e.element.name == prefix .. "-title" then
-        local procinfo = vars.procinfo --[[@as ProcInfo]]
+        local procinfo = vars.procinfo
+        if not procinfo then return end
         ---@type string | nil
         local text
         text = e.element.text
@@ -1032,7 +1036,7 @@ local function on_player_changed_surface(e)
         " has_procinfo=" .. tostring(procinfo ~= nil) ..
         " is_standard_exit=" .. tostring(is_standard_exit))
 
-    if procinfo and not procinfo.processor.valid then
+    if procinfo and (not procinfo.processor or not procinfo.processor.valid) then
         editor.restore_surface_list(player, "on_player_changed_surface")
         vars.procinfo = nil
         return
@@ -1044,7 +1048,7 @@ local function on_player_changed_surface(e)
         log("[compaktcircuit debug] on_player_changed_surface: leaving editor surface player=" .. e.player_index ..
             " surface=" .. tostring(procinfo.surface.name) ..
             " packed=" .. tostring(procinfo.is_packed))
-        editor.close_iopanel(player)
+        editor.close_all(player)
         editor.close_editor_panel(player)
         editor.restore_surface_list(player, "on_player_changed_surface")
 
@@ -1351,7 +1355,9 @@ local function on_marked_for_deconstruction(e)
         end
     end
 
-    if entity.valid and (commons.remote_controllers[player.controller_type] or need_mining) then
+    local player_surface = player.surface
+    local is_same_surface = player_surface and player_surface.valid and player_surface == entity.surface
+    if entity.valid and is_same_surface and (commons.remote_controllers[player.controller_type] or need_mining) then
         if entity.name == internal_iopoint_name then
             editor.destroy_internal_iopoint(entity)
         end
@@ -1550,7 +1556,7 @@ tools.on_nth_tick(300, function()
     local charted = {}
     for _, player in pairs(game.players) do
         local surface = player.surface
-        if string.find(surface.name, commons.surface_name_pattern) then
+        if surface and surface.valid and string.find(surface.name, commons.surface_name_pattern) then
             local key = player.force.name .. surface.name
             if not charted[key] then
                 surface.request_to_generate_chunks(player.position, 8)

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -275,7 +275,11 @@ function editor.edit_selected(player, processor)
     procinfo.physical_position = player.physical_position
 
     local x, y = editor.find_room(surface, 0, 0)
-    player.teleport({ x, y }, surface)
+    player.set_controller {
+        type = defines.controllers.remote,
+        position = { x, y },
+        surface = surface
+    }
 end
 
 ---@param procinfo ProcInfo

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -266,7 +266,7 @@ end
 
 ---@param procinfo ProcInfo
 ---@param player LuaPlayer
-local function exit_player(procinfo, player)
+local function restore_player_controller(procinfo, player)
     ---@type string
     local ret_surface_name
     ---@type MapPosition
@@ -286,7 +286,7 @@ local function exit_player(procinfo, player)
         ret_surface_position = { x = 0, y = 0 }
     end
 
-    log("[compaktcircuit debug] exit_player: player=" .. player.index ..
+    log("[compaktcircuit debug] restore_player_controller: player=" .. player.index ..
         " return_controller=" .. tostring(ret_controller_type) ..
         " return_surface=" .. tostring(ret_surface_name) ..
         " return_pos=" .. tostring(ret_surface_position.x) .. "," .. tostring(ret_surface_position.y))
@@ -301,14 +301,14 @@ local function exit_player(procinfo, player)
                     surface = character.surface
                 }
             end
-            log("[compaktcircuit debug] exit_player: restore character controller player=" .. player.index)
+            log("[compaktcircuit debug] restore_player_controller: restore character controller player=" .. player.index)
             player.set_controller {
                 type = defines.controllers.character,
                 character = character
             }
         end
     elseif ret_controller_type == defines.controllers.god then
-        log("[compaktcircuit debug] exit_player: teleport return player=" .. player.index)
+        log("[compaktcircuit debug] restore_player_controller: teleport return player=" .. player.index)
         player.teleport(ret_surface_position, ret_surface_name)
         local surface = game.surfaces[ret_surface_name]
         local platform = surface.platform
@@ -317,7 +317,7 @@ local function exit_player(procinfo, player)
         end
     else
         if procinfo.physical_controller_type then
-            log("[compaktcircuit debug] exit_player: restore physical player=" .. player.index ..
+            log("[compaktcircuit debug] restore_player_controller: restore physical player=" .. player.index ..
                 " surface=" .. tostring(procinfo.physical_surface_index))
             player.teleport(procinfo.physical_position, procinfo.physical_surface_index, false, false)
             local surface = game.surfaces[procinfo.physical_surface_index]
@@ -326,7 +326,7 @@ local function exit_player(procinfo, player)
                 player.enter_space_platform(platform)
             end
         end
-        log("[compaktcircuit debug] exit_player: set_controller return player=" .. player.index)
+        log("[compaktcircuit debug] restore_player_controller: set_controller return player=" .. player.index)
         player.set_controller {
             type = ret_controller_type,
             position = ret_surface_position,
@@ -334,7 +334,7 @@ local function exit_player(procinfo, player)
         }
     end
 
-    editor.restore_surface_list(player, "exit_player")
+    editor.restore_surface_list(player, "restore_player_controller")
 end
 
 ---@param player LuaPlayer
@@ -938,7 +938,7 @@ function editor.on_pre_surface_deleted(e)
     storage.surface_map[surface.name] = nil
     procinfo.surface = nil
     for _, player in pairs(game.players) do
-        if player.surface == surface then exit_player(procinfo, player) end
+        if player.surface == surface then restore_player_controller(procinfo, player) end
     end
 end
 

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -85,16 +85,8 @@ function editor.create_editor_panel(player, procinfo)
         style = "inside_shallow_frame_with_padding",
     }
 
-    local exit_flow = frame.add { type = "flow", direction = "horizontal" }
-    local b = exit_flow.add {
-        type = "button",
-        caption = { button_prefix .. ".exit_editor" },
-        name = prefix .. "-exit_editor",
-        tooltip = { tooltip_prefix .. ".exit" }
-    }
-    b.style.width = 160
-
-    b = exit_flow.add {
+    local top_flow = frame.add { type = "flow", direction = "horizontal" }
+    local b = top_flow.add {
         type = "button",
         caption = { button_prefix .. ".models" },
         name = prefix .. "-models",
@@ -209,28 +201,6 @@ tools.on_event(defines.events.on_gui_elem_changed,
 
 -----------------------------------------------------------------
 
----@param surface LuaSurface
----@param x number
----@param y number
----@return number
----@return number
-function editor.find_room(surface, x, y)
-    local count = 0
-    while true do
-        local entities = surface.find_entities({ { x - 1, y - 1 }, { x + 1, y + 1 } })
-        if #entities == 0 then break end
-        x = x + 1
-        if x > EDITOR_SIZE / 2 - 1 then
-            x = -EDITOR_SIZE / 2 + 1
-            y = y + 1
-            if y > EDITOR_SIZE / 2 - 1 then y = -EDITOR_SIZE / 2 + 1 end
-        end
-        count = count + 1
-        if count > 1000 then break end
-    end
-    return x, y
-end
-
 local allow_controller_types = {
 
     [defines.controllers.god] = true,
@@ -277,26 +247,18 @@ function editor.edit_selected(player, processor)
     procinfo.origin_surface_name = player.surface.name
     procinfo.origin_surface_position = player.position
     procinfo.origin_controller_type = player.controller_type
-    if not string.find(player.physical_surface.name, commons.surface_name_pattern) and
-        not string.find(procinfo.origin_surface_name, commons.surface_name_pattern) then
-        vars.physical_surface_index = player.physical_surface_index
-        vars.physical_controller_type = player.physical_controller_type
-        vars.physical_position = player.physical_position
-    end
     procinfo.physical_surface_index = player.physical_surface_index
     procinfo.physical_controller_type = player.physical_controller_type
     procinfo.physical_position = player.physical_position
 
-    local x, y = editor.find_room(surface, 0, 0)
     log("[compaktcircuit debug] edit_selected: enter remote player=" .. player.index ..
         " processor=" .. tostring(processor.unit_number) ..
         " origin_surface=" .. tostring(procinfo.origin_surface_name) ..
         " origin_controller=" .. tostring(procinfo.origin_controller_type) ..
-        " target_surface=" .. tostring(surface.name) ..
-        " target_pos=" .. tostring(x) .. "," .. tostring(y))
+        " target_surface=" .. tostring(surface.name))
     player.set_controller {
         type = defines.controllers.remote,
-        position = { x, y },
+        position = { 0, 0 },
         surface = surface
     }
     player.zoom = editor_remote_zoom
@@ -304,8 +266,7 @@ end
 
 ---@param procinfo ProcInfo
 ---@param player LuaPlayer
----@param to_origin boolean?
-local function exit_player(procinfo, player, to_origin)
+local function exit_player(procinfo, player)
     ---@type string
     local ret_surface_name
     ---@type MapPosition
@@ -315,18 +276,10 @@ local function exit_player(procinfo, player, to_origin)
     ---@type LuaSurface
     local ret_surface
 
-    local vars = tools.get_vars(player)
-    if not to_origin then
-        ret_surface_name = procinfo.origin_surface_name
-        ret_surface_position = procinfo.origin_surface_position
-        ret_controller_type = procinfo.origin_controller_type or defines.controllers.character
-        ret_surface = game.surfaces[ret_surface_name]
-    elseif vars.physical_surface_index then
-        ret_surface = game.surfaces[vars.physical_surface_index]
-        ret_surface_position = vars.physical_position
-        ret_controller_type = vars.physical_controller_type
-        ret_surface_name = ret_surface.name
-    end
+    ret_surface_name = procinfo.origin_surface_name
+    ret_surface_position = procinfo.origin_surface_position
+    ret_controller_type = procinfo.origin_controller_type or defines.controllers.character
+    ret_surface = game.surfaces[ret_surface_name]
 
     if not ret_surface or not ret_surface.valid then
         ret_surface_name = "nauvis"
@@ -334,14 +287,27 @@ local function exit_player(procinfo, player, to_origin)
     end
 
     log("[compaktcircuit debug] exit_player: player=" .. player.index ..
-        " to_origin=" .. tostring(to_origin) ..
         " return_controller=" .. tostring(ret_controller_type) ..
         " return_surface=" .. tostring(ret_surface_name) ..
         " return_pos=" .. tostring(ret_surface_position.x) .. "," .. tostring(ret_surface_position.y))
 
-    if ret_controller_type == defines.controllers.character
-        or ret_controller_type == defines.controllers.god
-    then
+    if ret_controller_type == defines.controllers.character then
+        local character = player.character
+        if character and character.valid then
+            if player.surface ~= character.surface then
+                player.set_controller {
+                    type = defines.controllers.remote,
+                    position = character.position,
+                    surface = character.surface
+                }
+            end
+            log("[compaktcircuit debug] exit_player: restore character controller player=" .. player.index)
+            player.set_controller {
+                type = defines.controllers.character,
+                character = character
+            }
+        end
+    elseif ret_controller_type == defines.controllers.god then
         log("[compaktcircuit debug] exit_player: teleport return player=" .. player.index)
         player.teleport(ret_surface_position, ret_surface_name)
         local surface = game.surfaces[ret_surface_name]
@@ -394,21 +360,6 @@ function editor.hide_surface_list(player, context)
         player.game_view_settings.show_surface_list = false
         log("[compaktcircuit debug] " .. context .. ": hide surface list player=" .. player.index)
     end
-end
-
----@param e EventData.on_gui_click
-local function on_exit_editor(e)
-    local player = game.players[e.player_index]
-    ccutils.close_all(player)
-    editor.close_editor_panel(player)
-
-    local vars = get_vars(player)
-    local procinfo = vars.procinfo
-    log("[compaktcircuit debug] on_exit_editor: player=" .. e.player_index ..
-        " control=" .. tostring(e.control) ..
-        " procinfo=" .. tostring(procinfo and procinfo.unit_number))
-    vars.is_standard_exit = true
-    exit_player(procinfo, player, e.control)
 end
 
 ---@param player LuaPlayer
@@ -554,7 +505,6 @@ local function on_models_open(e)
     tools.fire_user_event("models.open", player)
 end
 
-tools.on_gui_click(prefix .. "-exit_editor", on_exit_editor)
 tools.on_gui_click(prefix .. "-models", on_models_open)
 tools.on_gui_click(prefix .. "-add_iopole", on_add_pole)
 tools.on_gui_click(prefix .. "-add_internal_connector",
@@ -1283,6 +1233,9 @@ local function on_build(entity, e)
             if e.player_index then
                 local player = game.players[e.player_index]
                 if commons.remote_controllers[player.controller_type] then
+                    -- TODO: Implement item-request-proxy handling? vanilla combinators / allowed
+                    --       editor entities do not rely on modules, etc; but other mods may want
+                    --       that functionality to work?
                     entity.revive { raise_revive = true }
                 end
             end

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -30,6 +30,9 @@ local message_prefix = prefix .. "-message"
 local tooltip_prefix = prefix .. "-tooltip"
 local iopanel_name = prefix .. "-iopole_panel"
 
+-- Chosen slightly at random; I tried to pick a value that looked okay w/ a small-ish game-window ...
+local editor_remote_zoom = 1.0
+
 ---@param player LuaPlayer
 ---@return boolean
 function editor.close_editor_panel(player)
@@ -302,6 +305,7 @@ function editor.edit_selected(player, processor)
         position = { x, y },
         surface = surface
     }
+    player.zoom = editor_remote_zoom
 end
 
 ---@param procinfo ProcInfo

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -239,14 +239,22 @@ local allow_controller_types = {
 ---@param player LuaPlayer
 ---@param processor LuaEntity
 function editor.edit_selected(player, processor)
-    if storage.last_click and storage.last_click > game.tick - 120 then return end
+    if storage.last_click and storage.last_click > game.tick - 120 then
+        log("[compaktcircuit debug] edit_selected: ignored bounce click player=" .. player.index)
+        return
+    end
     storage.last_click = game.tick
 
     if not allow_controller_types[player.controller_type] then
+        log("[compaktcircuit debug] edit_selected: unsupported controller player=" .. player.index ..
+            " controller=" .. tostring(player.controller_type))
         return
     end
 
-    if not processor or not processor.valid then return end
+    if not processor or not processor.valid then
+        log("[compaktcircuit debug] edit_selected: invalid processor player=" .. player.index)
+        return
+    end
 
     local procinfo = get_procinfo(processor, true)
     ---@cast procinfo -nil
@@ -260,6 +268,7 @@ function editor.edit_selected(player, processor)
     end
     if player.game_view_settings.show_surface_list then
         player.game_view_settings.show_surface_list = false
+        log("[compaktcircuit debug] edit_selected: hide surface list player=" .. player.index)
     end
 
     if procinfo.is_packed then
@@ -282,6 +291,12 @@ function editor.edit_selected(player, processor)
     procinfo.physical_position = player.physical_position
 
     local x, y = editor.find_room(surface, 0, 0)
+    log("[compaktcircuit debug] edit_selected: enter remote player=" .. player.index ..
+        " processor=" .. tostring(processor.unit_number) ..
+        " origin_surface=" .. tostring(procinfo.origin_surface_name) ..
+        " origin_controller=" .. tostring(procinfo.origin_controller_type) ..
+        " target_surface=" .. tostring(surface.name) ..
+        " target_pos=" .. tostring(x) .. "," .. tostring(y))
     player.set_controller {
         type = defines.controllers.remote,
         position = { x, y },
@@ -319,9 +334,17 @@ local function exit_player(procinfo, player, to_origin)
         ret_surface_name = "nauvis"
         ret_surface_position = { x = 0, y = 0 }
     end
+
+    log("[compaktcircuit debug] exit_player: player=" .. player.index ..
+        " to_origin=" .. tostring(to_origin) ..
+        " return_controller=" .. tostring(ret_controller_type) ..
+        " return_surface=" .. tostring(ret_surface_name) ..
+        " return_pos=" .. tostring(ret_surface_position.x) .. "," .. tostring(ret_surface_position.y))
+
     if ret_controller_type == defines.controllers.character
         or ret_controller_type == defines.controllers.god
     then
+        log("[compaktcircuit debug] exit_player: teleport return player=" .. player.index)
         player.teleport(ret_surface_position, ret_surface_name)
         local surface = game.surfaces[ret_surface_name]
         local platform = surface.platform
@@ -330,6 +353,8 @@ local function exit_player(procinfo, player, to_origin)
         end
     else
         if procinfo.physical_controller_type then
+            log("[compaktcircuit debug] exit_player: restore physical player=" .. player.index ..
+                " surface=" .. tostring(procinfo.physical_surface_index))
             player.teleport(procinfo.physical_position, procinfo.physical_surface_index, false, false)
             local surface = game.surfaces[procinfo.physical_surface_index]
             local platform = surface.platform
@@ -337,6 +362,7 @@ local function exit_player(procinfo, player, to_origin)
                 player.enter_space_platform(platform)
             end
         end
+        log("[compaktcircuit debug] exit_player: set_controller return player=" .. player.index)
         player.set_controller {
             type = ret_controller_type,
             position = ret_surface_position,
@@ -347,6 +373,8 @@ local function exit_player(procinfo, player, to_origin)
     local vars = tools.get_vars(player)
     if vars.show_surface_list_before_editor ~= nil then
         player.game_view_settings.show_surface_list = vars.show_surface_list_before_editor
+        log("[compaktcircuit debug] exit_player: restore surface list player=" .. player.index ..
+            " value=" .. tostring(vars.show_surface_list_before_editor))
         vars.show_surface_list_before_editor = nil
     end
 end
@@ -359,6 +387,9 @@ local function on_exit_editor(e)
 
     local vars = get_vars(player)
     local procinfo = vars.procinfo
+    log("[compaktcircuit debug] on_exit_editor: player=" .. e.player_index ..
+        " control=" .. tostring(e.control) ..
+        " procinfo=" .. tostring(procinfo and procinfo.unit_number))
     vars.is_standard_exit = true
     exit_player(procinfo, player, e.control)
 end
@@ -1028,6 +1059,12 @@ local function on_player_changed_surface(e)
     local is_standard_exit = vars.is_standard_exit
     vars.is_standard_exit = false
 
+    log("[compaktcircuit debug] on_player_changed_surface: player=" .. e.player_index ..
+        " from_surface_index=" .. tostring(e.surface_index) ..
+        " current_surface=" .. tostring(player.surface.name) ..
+        " has_procinfo=" .. tostring(procinfo ~= nil) ..
+        " is_standard_exit=" .. tostring(is_standard_exit))
+
     if procinfo and not procinfo.processor.valid then
         vars.procinfo = nil
         return
@@ -1036,6 +1073,9 @@ local function on_player_changed_surface(e)
     -- Exiting surface
     if procinfo and procinfo.surface and procinfo.surface.valid and
         procinfo.surface.index == e.surface_index then
+        log("[compaktcircuit debug] on_player_changed_surface: leaving editor surface player=" .. e.player_index ..
+            " surface=" .. tostring(procinfo.surface.name) ..
+            " packed=" .. tostring(procinfo.is_packed))
         editor.close_iopanel(player)
         editor.close_editor_panel(player)
 
@@ -1065,6 +1105,9 @@ local function on_player_changed_surface(e)
     local surface_name = player.surface.name
     procinfo = storage.surface_map[surface_name]
     if procinfo then
+        log("[compaktcircuit debug] on_player_changed_surface: entering editor surface player=" .. e.player_index ..
+            " surface=" .. tostring(surface_name) ..
+            " processor=" .. tostring(procinfo.processor and procinfo.processor.name))
         vars.procinfo = procinfo
         vars.processor = procinfo.processor
         editor.create_editor_panel(player, procinfo)

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -1026,6 +1026,9 @@ local function on_player_changed_surface(e)
     local player = game.players[e.player_index]
     local vars = get_vars(player)
     local procinfo = vars.procinfo
+    local previous_surface = game.surfaces[e.surface_index]
+    local from_proc_surface = previous_surface and previous_surface.valid and
+        storage.surface_map[previous_surface.name] ~= nil
 
     local is_standard_exit = vars.is_standard_exit
     vars.is_standard_exit = false
@@ -1084,6 +1087,9 @@ local function on_player_changed_surface(e)
         editor.hide_surface_list(player, "on_player_changed_surface")
         vars.procinfo = procinfo
         vars.processor = procinfo.processor
+        if from_proc_surface and math.abs(player.zoom - editor_remote_zoom) > 0.001 then
+            player.zoom = editor_remote_zoom
+        end
         player.surface.request_to_generate_chunks(player.position, 8)
         player.force.chart_all(player.surface)
         editor.create_editor_panel(player, procinfo)

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -202,12 +202,41 @@ tools.on_event(defines.events.on_gui_elem_changed,
 -----------------------------------------------------------------
 
 local allow_controller_types = {
-
-    [defines.controllers.god] = true,
     [defines.controllers.character] = true,
     [defines.controllers.remote] = true,
-    [defines.controllers.editor] = true
+    [defines.controllers.editor] = true,
+    [defines.controllers.god] = true
 }
+
+local controller_names = {}
+for name, value in pairs(defines.controllers) do
+    if type(value) == "number" then
+        controller_names[value] = name
+    end
+end
+
+---@param player LuaPlayer
+---@return string?
+local function get_processor_entry_block_reason(player)
+    if not allow_controller_types[player.controller_type] then
+        return "controller is unsupported"
+    end
+
+    if player.controller_type ~= defines.controllers.remote then
+        return nil
+    end
+
+    if player.physical_controller_type ~= defines.controllers.character then
+        return "remote view is not backed by a character"
+    end
+
+    local physical_surface = player.physical_surface
+    if physical_surface and physical_surface.platform then
+        return "remote view is backed by a platform"
+    end
+
+    return nil
+end
 
 ---@param player LuaPlayer
 ---@param processor LuaEntity
@@ -218,9 +247,16 @@ function editor.edit_selected(player, processor)
     end
     storage.last_click = game.tick
 
-    if not allow_controller_types[player.controller_type] then
-        log("[compaktcircuit debug] edit_selected: unsupported controller player=" .. player.index ..
-            " controller=" .. tostring(player.controller_type))
+    local blocked_reason = get_processor_entry_block_reason(player)
+    if blocked_reason then
+        log("[compaktcircuit debug] edit_selected: blocked unsafe entry player=" .. player.index ..
+            " controller=" .. tostring(player.controller_type) ..
+            " physical_controller=" .. tostring(player.physical_controller_type) ..
+            " physical_surface=" .. tostring(player.physical_surface_index) ..
+            " reason=" .. blocked_reason)
+        player.print("CompaktCircuits: unsafe processor entry blocked from " ..
+            (controller_names[player.controller_type] or tostring(player.controller_type)) ..
+            " (" .. blocked_reason .. ").")
         return
     end
 
@@ -1045,25 +1081,20 @@ local function on_player_changed_surface(e)
         return
     end
 
-    -- Exiting surface
-    if procinfo and procinfo.surface and procinfo.surface.valid and
-        procinfo.surface.index == e.surface_index then
-        log("[compaktcircuit debug] on_player_changed_surface: leaving editor surface player=" .. e.player_index ..
-            " surface=" .. tostring(procinfo.surface.name) ..
-            " packed=" .. tostring(procinfo.is_packed))
+    local function finish_processor_exit(current_procinfo, standard_exit, context)
         editor.close_all(player)
         editor.close_editor_panel(player)
-        editor.restore_surface_list(player, "on_player_changed_surface")
+        editor.restore_surface_list(player, context)
 
         player.opened = nil
         vars.procinfo = nil
         vars.processor = nil
-        procinfo.tick = game.tick
-        build.save_packed_circuits(procinfo)
-        if (procinfo.is_packed) then
-            if is_standard_exit then
-                editor.delete_surface(procinfo)
-                local _, recursionError = build.create_packed_circuit(procinfo)
+        current_procinfo.tick = game.tick
+        build.save_packed_circuits(current_procinfo)
+        if current_procinfo.is_packed then
+            if standard_exit then
+                editor.delete_surface(current_procinfo)
+                local _, recursionError = build.create_packed_circuit(current_procinfo)
                 input.apply_parameters(procinfo)
                 if recursionError then
                     player.print {
@@ -1071,11 +1102,20 @@ local function on_player_changed_surface(e)
                     }
                 end
             else
-                build.destroy_packed_circuit(procinfo)
-                build.connect_all_iopoints(procinfo)
-                procinfo.is_packed = false
+                build.destroy_packed_circuit(current_procinfo)
+                build.connect_all_iopoints(current_procinfo)
+                current_procinfo.is_packed = false
             end
         end
+    end
+
+    -- Exiting surface
+    if procinfo and procinfo.surface and procinfo.surface.valid and
+        procinfo.surface.index == e.surface_index then
+        log("[compaktcircuit debug] on_player_changed_surface: leaving editor surface player=" .. e.player_index ..
+            " surface=" .. tostring(procinfo.surface.name) ..
+            " packed=" .. tostring(procinfo.is_packed))
+        finish_processor_exit(procinfo, is_standard_exit, "on_player_changed_surface")
     end
 
     local surface_name = player.surface.name
@@ -1096,6 +1136,35 @@ local function on_player_changed_surface(e)
     end
 end
 
+---@param e EventData.on_player_controller_changed
+local function on_player_controller_changed(e)
+    if e.old_type ~= defines.controllers.remote then return end
+
+    local player = game.players[e.player_index]
+    if player.controller_type == defines.controllers.remote then return end
+
+    local vars = get_vars(player)
+    local procinfo = vars.procinfo
+    if not procinfo or not procinfo.surface or not procinfo.surface.valid then return end
+    if player.surface ~= procinfo.surface then return end
+
+    log("[compaktcircuit debug] on_player_controller_changed: restoring player=" .. e.player_index ..
+        " old_controller=" .. (controller_names[e.old_type] or tostring(e.old_type)) ..
+        " new_controller=" .. (controller_names[player.controller_type] or tostring(player.controller_type)) ..
+        " surface=" .. tostring(player.surface.name))
+
+    editor.close_all(player)
+    editor.close_editor_panel(player)
+    editor.restore_surface_list(player, "on_player_controller_changed")
+
+    player.opened = nil
+    vars.procinfo = nil
+    vars.processor = nil
+    procinfo.tick = game.tick
+    build.save_packed_circuits(procinfo)
+    restore_player_controller(procinfo, player)
+end
+
 ---------------------------------------------------------------
 
 ---@param e EventData.on_gui_click
@@ -1113,6 +1182,8 @@ tools.on_event(defines.events.on_gui_checked_state_changed,
 tools.on_event(defines.events.on_gui_text_changed, on_gui_text_changed)
 tools.on_event(defines.events.on_player_changed_surface,
     on_player_changed_surface)
+tools.on_event(defines.events.on_player_controller_changed,
+    on_player_controller_changed)
 
 --------------------------------------------------------------------------------------
 

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -201,11 +201,14 @@ tools.on_event(defines.events.on_gui_elem_changed,
 
 -----------------------------------------------------------------
 
+-- Controller types supported for processor entry
+-- https://lua-api.factorio.com/latest/defines.html#defines.controllers
 local allow_controller_types = {
     [defines.controllers.character] = true,
     [defines.controllers.remote] = true,
     [defines.controllers.editor] = true,
-    [defines.controllers.god] = true
+    [defines.controllers.god] = true,
+    [defines.controllers.spectator] = true
 }
 
 local controller_names = {}
@@ -226,13 +229,8 @@ local function get_processor_entry_block_reason(player)
         return nil
     end
 
-    if player.physical_controller_type ~= defines.controllers.character then
-        return "remote view is not backed by a character"
-    end
-
-    local physical_surface = player.physical_surface
-    if physical_surface and physical_surface.platform then
-        return "remote view is backed by a platform"
+    if not allow_controller_types[player.physical_controller_type] then
+        return "remote view backing controller is unsupported"
     end
 
     return nil
@@ -250,6 +248,8 @@ function editor.edit_selected(player, processor)
     local blocked_reason = get_processor_entry_block_reason(player)
     if blocked_reason then
         debug("edit_selected: blocked unsafe entry player=" .. player.index ..
+            " controller=" .. tostring(player.controller_type) ..
+            " physical_controller=" .. tostring(player.physical_controller_type) ..
             " physical_surface=" .. tostring(player.physical_surface_index) ..
             " reason=" .. blocked_reason)
         player.print("CompaktCircuits: unsafe processor entry blocked from " ..

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -255,6 +255,13 @@ function editor.edit_selected(player, processor)
     vars.processor = processor
     local surface = editor.get_or_create_surface(procinfo)
 
+    if vars.show_surface_list_before_editor == nil then
+        vars.show_surface_list_before_editor = player.game_view_settings.show_surface_list
+    end
+    if player.game_view_settings.show_surface_list then
+        player.game_view_settings.show_surface_list = false
+    end
+
     if procinfo.is_packed then
         build.restore_packed_circuits(procinfo)
         input.apply_parameters(procinfo)
@@ -335,6 +342,12 @@ local function exit_player(procinfo, player, to_origin)
             position = ret_surface_position,
             surface = ret_surface_name
         }
+    end
+
+    local vars = tools.get_vars(player)
+    if vars.show_surface_list_before_editor ~= nil then
+        player.game_view_settings.show_surface_list = vars.show_surface_list_before_editor
+        vars.show_surface_list_before_editor = nil
     end
 end
 

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -290,6 +290,8 @@ function editor.edit_selected(player, processor)
         " origin_surface=" .. tostring(procinfo.origin_surface_name) ..
         " origin_controller=" .. tostring(procinfo.origin_controller_type) ..
         " target_surface=" .. tostring(surface.name))
+    vars.pending_processor_entry_surface = surface.name
+    vars.pending_processor_entry_tick = game.tick
     player.set_controller {
         type = defines.controllers.remote,
         position = { 0, 0 },
@@ -343,6 +345,9 @@ local function restore_player_controller(procinfo, player)
         end
     elseif ret_controller_type == defines.controllers.god then
         debug("restore_player_controller: teleport return player=" .. player.index)
+        player.set_controller {
+            type = defines.controllers.god
+        }
         player.teleport(ret_surface_position, ret_surface_name)
         local surface = game.surfaces[ret_surface_name]
         local platform = surface.platform
@@ -1114,11 +1119,38 @@ local function on_player_changed_surface(e)
             " surface=" .. tostring(procinfo.surface.name) ..
             " packed=" .. tostring(procinfo.is_packed))
         finish_processor_exit(procinfo, is_standard_exit, "on_player_changed_surface")
+
+        -- Fallback for mod interactions where remote exits directly to physical character
+        -- before controller-changed restoration can run (for example sandbox god flows).
+        if not is_standard_exit and
+            procinfo.origin_controller_type == defines.controllers.god and
+            player.surface and player.surface.name ~= procinfo.origin_surface_name then
+            debug("on_player_changed_surface: fallback restore god-origin player=" .. e.player_index ..
+                " current_surface=" .. tostring(player.surface.name) ..
+                " origin_surface=" .. tostring(procinfo.origin_surface_name))
+            restore_player_controller(procinfo, player)
+        end
     end
 
     local surface_name = player.surface.name
     procinfo = storage.surface_map[surface_name]
     if procinfo then
+        local intentional_processor_entry =
+            vars.pending_processor_entry_surface == surface_name and
+            vars.pending_processor_entry_tick == game.tick
+        vars.pending_processor_entry_surface = nil
+        vars.pending_processor_entry_tick = nil
+
+        if not intentional_processor_entry and
+            from_proc_surface then
+            debug("on_player_changed_surface: editor nested escape hard-unwind player=" .. e.player_index ..
+                " surface=" .. tostring(surface_name) ..
+                " origin_surface=" .. tostring(procinfo.origin_surface_name))
+            finish_processor_exit(procinfo, false, "on_player_changed_surface/editor_nested_escape")
+            restore_player_controller(procinfo, player)
+            return
+        end
+
         debug("on_player_changed_surface: entering editor surface player=" .. e.player_index ..
             " surface=" .. tostring(surface_name) ..
             " processor=" .. tostring(procinfo.processor and procinfo.processor.name))

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -266,13 +266,7 @@ function editor.edit_selected(player, processor)
     vars.processor = processor
     local surface = editor.get_or_create_surface(procinfo)
 
-    if vars.show_surface_list_before_editor == nil then
-        vars.show_surface_list_before_editor = player.game_view_settings.show_surface_list
-    end
-    if player.game_view_settings.show_surface_list then
-        player.game_view_settings.show_surface_list = false
-        log("[compaktcircuit debug] edit_selected: hide surface list player=" .. player.index)
-    end
+    editor.hide_surface_list(player, "edit_selected")
 
     if procinfo.is_packed then
         build.restore_packed_circuits(procinfo)
@@ -374,12 +368,31 @@ local function exit_player(procinfo, player, to_origin)
         }
     end
 
+    editor.restore_surface_list(player, "exit_player")
+end
+
+---@param player LuaPlayer
+---@param context string
+function editor.restore_surface_list(player, context)
     local vars = tools.get_vars(player)
     if vars.show_surface_list_before_editor ~= nil then
         player.game_view_settings.show_surface_list = vars.show_surface_list_before_editor
-        log("[compaktcircuit debug] exit_player: restore surface list player=" .. player.index ..
+        log("[compaktcircuit debug] " .. context .. ": restore surface list player=" .. player.index ..
             " value=" .. tostring(vars.show_surface_list_before_editor))
         vars.show_surface_list_before_editor = nil
+    end
+end
+
+---@param player LuaPlayer
+---@param context string
+function editor.hide_surface_list(player, context)
+    local vars = tools.get_vars(player)
+    if vars.show_surface_list_before_editor == nil then
+        vars.show_surface_list_before_editor = player.game_view_settings.show_surface_list
+    end
+    if player.game_view_settings.show_surface_list then
+        player.game_view_settings.show_surface_list = false
+        log("[compaktcircuit debug] " .. context .. ": hide surface list player=" .. player.index)
     end
 end
 
@@ -1070,6 +1083,7 @@ local function on_player_changed_surface(e)
         " is_standard_exit=" .. tostring(is_standard_exit))
 
     if procinfo and not procinfo.processor.valid then
+        editor.restore_surface_list(player, "on_player_changed_surface")
         vars.procinfo = nil
         return
     end
@@ -1082,6 +1096,7 @@ local function on_player_changed_surface(e)
             " packed=" .. tostring(procinfo.is_packed))
         editor.close_iopanel(player)
         editor.close_editor_panel(player)
+        editor.restore_surface_list(player, "on_player_changed_surface")
 
         player.opened = nil
         vars.procinfo = nil
@@ -1112,6 +1127,7 @@ local function on_player_changed_surface(e)
         log("[compaktcircuit debug] on_player_changed_surface: entering editor surface player=" .. e.player_index ..
             " surface=" .. tostring(surface_name) ..
             " processor=" .. tostring(procinfo.processor and procinfo.processor.name))
+        editor.hide_surface_list(player, "on_player_changed_surface")
         vars.procinfo = procinfo
         vars.processor = procinfo.processor
         player.surface.request_to_generate_chunks(player.position, 8)

--- a/scripts/editor.lua
+++ b/scripts/editor.lua
@@ -1110,6 +1110,8 @@ local function on_player_changed_surface(e)
             " processor=" .. tostring(procinfo.processor and procinfo.processor.name))
         vars.procinfo = procinfo
         vars.processor = procinfo.processor
+        player.surface.request_to_generate_chunks(player.position, 8)
+        player.force.chart_all(player.surface)
         editor.create_editor_panel(player, procinfo)
     end
 end
@@ -1563,5 +1565,27 @@ remote.add_interface(prefix, {
 ---@param tags Tags
 function editor.save_undo_tags(player_index, pos, tags)
 end
+
+-- eager chunk generation at surface creation isn't always enough; the game
+-- defers some of it, leaving a black map until generation catches up. re-requesting
+-- periodically while a player is inside covers the gap.
+--
+-- approach copied shamelessley from Blueprint Sandboxes:
+-- <https://github.com/cameronleger/blueprint-sandboxes/blob/06b7612d/control.lua#L221-L222>,
+-- <https://github.com/cameronleger/blueprint-sandboxes/blob/06b7612d/scripts/remote-view.lua#L106-L118>
+tools.on_nth_tick(300, function()
+    local charted = {}
+    for _, player in pairs(game.players) do
+        local surface = player.surface
+        if string.find(surface.name, commons.surface_name_pattern) then
+            local key = player.force.name .. surface.name
+            if not charted[key] then
+                surface.request_to_generate_chunks(player.position, 8)
+                player.force.chart_all(surface)
+                charted[key] = true
+            end
+        end
+    end
+end)
 
 return editor

--- a/scripts/input.lua
+++ b/scripts/input.lua
@@ -1297,6 +1297,7 @@ function input.load_property_values(player)
     if not frame then return end
 
     local procinfo = vars.input_procinfo --[[@as ProcInfo]]
+    if not procinfo then return end
 
     local property_table = tools.get_child(frame, "properties")
     if not property_table then return end

--- a/scripts/models_lib.lua
+++ b/scripts/models_lib.lua
@@ -280,8 +280,6 @@ local function import_model(player)
     local model_info = models[procinfo.model]
     if not model_info then return end
 
-    local position = player.position
-    player.teleport { -EDITOR_SIZE / 2 + 1, -EDITOR_SIZE / 2 + 1 }
     editor.clean_surface(procinfo)
     procinfo.circuits = model_info.circuits
     procinfo.blueprint = model_info.blueprint
@@ -306,8 +304,6 @@ local function import_model(player)
         end
     end
 
-    local x, y = editor.find_room(player.surface, position.x, position.y)
-    player.teleport({ x, y })
     input.apply_parameters(procinfo)
 end
 

--- a/scripts/models_lib.lua
+++ b/scripts/models_lib.lua
@@ -28,6 +28,63 @@ local frame_name = np("frame")
 local get_procinfo = build.get_procinfo
 
 ---@param player LuaPlayer
+local function notify_no_active_processor(player)
+    local message = "CompaktCircuits: action cancelled (no active processor view)."
+    log(message)
+    player.print(message)
+end
+
+---@param player LuaPlayer
+---@return ProcInfo?
+local function get_active_procinfo(player)
+    local procinfo = storage.surface_map[player.surface.name]
+    if not procinfo then return nil end
+    if not procinfo.processor or not procinfo.processor.valid then return nil end
+    return procinfo
+end
+
+---@param player LuaPlayer
+---@return ProcInfo?
+local function get_action_procinfo(player)
+    local active_procinfo = get_active_procinfo(player)
+    if active_procinfo then return active_procinfo end
+
+    local vars = get_vars(player)
+    local model_procinfo = vars.model_procinfo
+    if model_procinfo and model_procinfo.processor and model_procinfo.processor.valid then
+        return model_procinfo
+    end
+
+    vars.model_procinfo = nil
+    return nil
+end
+
+---@param player LuaPlayer
+---@return ProcInfo?
+local function require_action_procinfo(player)
+    local procinfo = get_action_procinfo(player)
+    if procinfo then return procinfo end
+    local vars = get_vars(player)
+    vars.model_action = nil
+    vars.model_procinfo = nil
+    notify_no_active_processor(player)
+    return nil
+end
+
+---@param player LuaPlayer
+---@param action string
+---@return ProcInfo?
+local function prepare_model_action(player, action)
+    local vars = get_vars(player)
+    vars.model_action = action
+    vars.model_procinfo = get_active_procinfo(player)
+    if vars.model_procinfo then return vars.model_procinfo end
+    vars.model_action = nil
+    notify_no_active_processor(player)
+    return nil
+end
+
+---@param player LuaPlayer
 ---@param processor_name string
 ---@return string[] @ Model names
 local function get_model_list(player, processor_name)
@@ -66,6 +123,7 @@ function models_lib.create_panel(player)
 
     local procinfo = storage.surface_map[player.surface.name]
     if not procinfo then return end
+    get_vars(player).model_procinfo = procinfo
 
     ccutils.close_all(player)
 
@@ -180,7 +238,7 @@ function models_lib.create_panel(player)
     end
 end
 
-tools.on_gui_click(np("close"), 
+tools.on_gui_click(np("close"),
 ---@param e EventData.on_gui_click
 function(e)
     models_lib.close(game.players[e.player_index])
@@ -193,6 +251,9 @@ function models_lib.close(player)
         tools.get_vars(player).models_location = frame.location
         frame.destroy()
     end
+    local vars = get_vars(player)
+    vars.model_action = nil
+    vars.model_procinfo = nil
 end
 
 ---@param player LuaPlayer
@@ -214,6 +275,10 @@ end
 local function set_label_mode(player, text_mode, action_mode, ok_text)
     local model_flow = get_model_flow(player)
     local model_button_flow = get_model_button_flow(player)
+
+    if not model_flow[prefix .. "-model_list"] or not model_button_flow[prefix .. "-ok_button"] then
+        return
+    end
 
     model_flow[prefix .. "-model_list"].visible = not text_mode
 
@@ -242,8 +307,9 @@ local function refresh_model_list(player, procinfo)
     cb.selected_index = index
 end
 
-local function add_model(player)
-    local procinfo = storage.surface_map[player.surface.name]
+---@param player LuaPlayer
+---@param procinfo ProcInfo
+local function add_model(player, procinfo)
     local model_flow = get_model_flow(player)
     local model_name = model_flow[prefix .. "-model_name"].text
 
@@ -271,9 +337,8 @@ local function add_model(player)
 end
 
 ---@param player LuaPlayer
-local function import_model(player)
-    --- @type ProcInfo
-    local procinfo = storage.surface_map[player.surface.name]
+---@param procinfo ProcInfo
+local function import_model(player, procinfo)
     if procinfo.model == nil then return end
 
     local models = build.get_models(player.force, procinfo.processor.name)
@@ -308,9 +373,8 @@ local function import_model(player)
 end
 
 ---@param player LuaPlayer
-local function rename_model(player)
-    ---@type ProcInfo
-    local procinfo = storage.surface_map[player.surface.name]
+---@param procinfo ProcInfo
+local function rename_model(player, procinfo)
     if procinfo.model == nil then return end
 
     --[[
@@ -435,9 +499,8 @@ function models_lib.update_model(procinfo, model, current)
 end
 
 ---@param player LuaPlayer
-local function apply_model(player)
-    ---@type ProcInfo
-    local model_procinfo = storage.surface_map[player.surface.name]
+---@param model_procinfo ProcInfo
+local function apply_model(player, model_procinfo)
     if not model_procinfo.model then return end
 
     local force = player.force
@@ -519,9 +582,8 @@ function models_lib.copy_from(procinfo, src_procinfo, packed)
 end
 
 ---@param player LuaPlayer
-local function remove_model(player)
-    ---@type ProcInfo
-    local procinfo = storage.surface_map[player.surface.name]
+---@param procinfo ProcInfo
+local function remove_model(player, procinfo)
 
     if not procinfo.model then return end
     local models = build.get_models(player.force, procinfo.processor.name)
@@ -532,19 +594,35 @@ end
 
 ---@param player LuaPlayer
 local function execute_model_action(player)
-    local model_action = get_vars(player).model_action
+    local vars = get_vars(player)
+    local model_action = vars.model_action
+
+    if model_action == nil or model_action == "" then
+        return
+    end
+
+    local procinfo = require_action_procinfo(player)
+    if not procinfo then
+        set_label_mode(player, false, false)
+        vars.model_action = nil
+        vars.model_procinfo = nil
+        return
+    end
+
     set_label_mode(player, false, false)
     if model_action == "add" then
-        add_model(player)
+        add_model(player, procinfo)
     elseif model_action == "rename" then
-        rename_model(player)
+        rename_model(player, procinfo)
     elseif model_action == "apply" then
-        apply_model(player)
+        apply_model(player, procinfo)
     elseif model_action == "import" then
-        import_model(player)
+        import_model(player, procinfo)
     elseif model_action == "remove" then
-        remove_model(player)
+        remove_model(player, procinfo)
     end
+    vars.model_action = nil
+    vars.model_procinfo = nil
 end
 
 
@@ -554,7 +632,8 @@ tools.on_event(defines.events.on_gui_selection_state_changed,
         if not e.element.valid or e.element.name ~= prefix .. "-model_list" then return end
 
         local player = game.players[e.player_index]
-        local procinfo = storage.surface_map[player.surface.name]
+        local procinfo = get_action_procinfo(player)
+        if not procinfo then return end
         if e.element.selected_index == 1 then
             procinfo.model = nil
         else
@@ -574,7 +653,7 @@ tools.on_gui_click(prefix .. "-new_model_button",
     ---@param e EventData.on_gui_click
     function(e)
         local player = game.players[e.player_index]
-        get_vars(player).model_action = "add"
+        if not prepare_model_action(player, "add") then return end
         set_label_mode(player, true, true, { button_prefix .. ".new_model" })
     end)
 
@@ -583,20 +662,27 @@ tools.on_gui_click(prefix .. "-rename_button",
     function(e)
         local player = game.players[e.player_index]
 
-        local procinfo = storage.surface_map[player.surface.name]
-        if procinfo.model == nil then return end
+        local vars = get_vars(player)
+        local procinfo = prepare_model_action(player, "rename")
+        if not procinfo then return end
+
+        if procinfo.model == nil then
+            vars.model_action = nil
+            vars.model_procinfo = nil
+            player.print("CompaktCircuits: rename cancelled (no model selected).")
+            return
+        end
 
         local model_flow = get_model_flow(player)
         model_flow[prefix .. "-model_name"].text = procinfo.model
 
-        get_vars(player).model_action = "rename"
         set_label_mode(player, true, true, { button_prefix .. ".rename_model" })
     end)
 
 tools.on_gui_click(prefix .. "-import_model", ---@param e EventData.on_gui_click
     function(e)
         local player = game.players[e.player_index]
-        get_vars(player).model_action = "import"
+        if not prepare_model_action(player, "import") then return end
         set_label_mode(player, false, true,
             { button_prefix .. ".import_model_confirm" })
     end)
@@ -604,7 +690,7 @@ tools.on_gui_click(prefix .. "-import_model", ---@param e EventData.on_gui_click
 tools.on_gui_click(prefix .. "-apply_model", ---@param e EventData.on_gui_click
     function(e)
         local player = game.players[e.player_index]
-        get_vars(player).model_action = "apply"
+        if not prepare_model_action(player, "apply") then return end
         set_label_mode(player, false, true,
             { button_prefix .. ".apply_model_confirm" })
     end)
@@ -612,7 +698,7 @@ tools.on_gui_click(prefix .. "-apply_model", ---@param e EventData.on_gui_click
 tools.on_gui_click(prefix .. "-remove_model", ---@param e EventData.on_gui_click
     function(e)
         local player = game.players[e.player_index]
-        get_vars(player).model_action = "remove"
+        if not prepare_model_action(player, "remove") then return end
         set_label_mode(player, false, true,
             { button_prefix .. ".remove_model_confirm" })
     end)
@@ -699,14 +785,19 @@ tools.on_gui_click(prefix .. "-import_models", ---@param e EventData.on_gui_clic
                 end
             end
         end
-        local procinfo = storage.surface_map[player.surface.name]
-        refresh_model_list(player, procinfo)
+        local procinfo = get_active_procinfo(player)
+        if procinfo then
+            refresh_model_list(player, procinfo)
+        end
     end)
 
 tools.on_gui_click(prefix .. "-cancel_button",
     ---@param e EventData.on_gui_click
     function(e)
         local player = game.players[e.player_index]
+        local vars = get_vars(player)
+        vars.model_action = nil
+        vars.model_procinfo = nil
         set_label_mode(player, false, false)
     end)
 

--- a/scripts/processor.lua
+++ b/scripts/processor.lua
@@ -588,24 +588,24 @@ local function on_gui_open_processor_panel(event)
     if not entity or not entity.valid then return end
 
     if entity.name == device_name then
-        log("[compaktcircuit debug] on_gui_open_processor_panel: device opened player=" .. event.player_index ..
+        debug("on_gui_open_processor_panel: device opened player=" .. event.player_index ..
             " entity=" .. tostring(entity.unit_number) ..
             " surface=" .. tostring(entity.surface and entity.surface.name))
         player.opened = nil
         local processor = find_processor(entity)
         if not processor then
-            log("[compaktcircuit debug] on_gui_open_processor_panel: no processor found player=" ..
+            debug("on_gui_open_processor_panel: no processor found player=" ..
                 event.player_index)
             return
         end
 
-        log("[compaktcircuit debug] on_gui_open_processor_panel: entering processor player=" ..
+        debug("on_gui_open_processor_panel: entering processor player=" ..
             event.player_index .. " processor=" .. tostring(processor.unit_number) ..
             " surface=" .. tostring(processor.surface and processor.surface.name))
 
         editor.edit_selected(player, processor)
     elseif entity.name == iopoint_name then
-        log("[compaktcircuit debug] on_gui_open_processor_panel: iopoint opened player=" ..
+        debug("on_gui_open_processor_panel: iopoint opened player=" ..
             event.player_index .. " entity=" .. tostring(entity.unit_number))
         player.opened = nil
     end

--- a/scripts/processor.lua
+++ b/scripts/processor.lua
@@ -1918,8 +1918,10 @@ tools.on_event(defines.events.on_marked_for_deconstruction,
                 end
 
                 local player = game.players[e.player_index]
+                local player_surface = player.surface
+                local is_same_surface = player_surface and player_surface.valid and player_surface == entity.surface
                 local procinfo = storage.surface_map and storage.surface_map[entity.surface.name]
-                if procinfo and commons.remote_controllers[player.controller_type] then
+                if procinfo and is_same_surface and commons.remote_controllers[player.controller_type] then
                     save_undo_tags(e.player_index, entity.position, tags)
                     entity.mine { raise_destroyed = true }
                     return

--- a/scripts/processor.lua
+++ b/scripts/processor.lua
@@ -588,12 +588,25 @@ local function on_gui_open_processor_panel(event)
     if not entity or not entity.valid then return end
 
     if entity.name == device_name then
+        log("[compaktcircuit debug] on_gui_open_processor_panel: device opened player=" .. event.player_index ..
+            " entity=" .. tostring(entity.unit_number) ..
+            " surface=" .. tostring(entity.surface and entity.surface.name))
         player.opened = nil
         local processor = find_processor(entity)
-        if not processor then return end
+        if not processor then
+            log("[compaktcircuit debug] on_gui_open_processor_panel: no processor found player=" ..
+                event.player_index)
+            return
+        end
+
+        log("[compaktcircuit debug] on_gui_open_processor_panel: entering processor player=" ..
+            event.player_index .. " processor=" .. tostring(processor.unit_number) ..
+            " surface=" .. tostring(processor.surface and processor.surface.name))
 
         editor.edit_selected(player, processor)
     elseif entity.name == iopoint_name then
+        log("[compaktcircuit debug] on_gui_open_processor_panel: iopoint opened player=" ..
+            event.player_index .. " entity=" .. tostring(entity.unit_number))
         player.opened = nil
     end
 end


### PR DESCRIPTION
Now that 'remote view' is very mature and heavily leveraged by mods like Blueprint Sandbox, basically all of the teleporting-the-character-around was a bit crufty and a smell that causes a lot of weird edge-cases and bugs. (Exiting to the wrong planet, entering a processor from a vehicle, bots-in-flight when entering/exiting, ...)

This was just an experiment, but after a good bit of playing, I have yet to run into any failure modes that aren't fixed or improved - I'll mark the PR for review once I've *played* with this a bit more in actual play, I suppose.

This PR completely removes anything that moves the player-character around. (It is now an invariant that the player-character should *never* be physically "inside" a processor.)

Also, thanks to defaulting to remote-view, a lot more care needed to be taken with various functionality - remote-view can be closed at any time with "esc", and various UI was making unsafe assumptions about surface-access and so-on. Like 70% of this PR is additional error-checking, state-saving, and error-handling, just to be extra robust and safe.

----

There's some things here which are a bit subtle, and don't really have a "clearly correct" behaviour - so they're effectively design-decisions I made:

1. In vanilla Factorio, when entering "remote view" from within `/editor` (or god-mode, or spectator - anything without a physical backing character), if you then navigate using the map-view to another surface/planet and hit "escape", you're fully teleported there - i.e. the editor/god camera moves fully to that other planet/surface. (i.e. it's a vanilla invariant that non-character remote-view-windows always "exit" to precisely where they're looking, not where you entered remote-view from. I hate this behaviour, as it loses my mental context, but whatever.)

   We can't allow that, though - we *do not want* the editor/god literally inside the processor "surface", because then the player is at risk of spawning their character inside the processor if they `/editor` to leave editor-mode when they're done; and that breaks *our* invariant.
   
   There's a couple potential approaches to this:
   
   - prevent entering processors in editor/god-mode
   - override exiting god-remote to return the god-camera to the surface they entered remote-view from (my preferred beaviour, but breaks with vanilla more, and also more work to implement)
   - override exiting god-remote to return the god-camera to the last surface they were on when they entered the processor (the "closest" to vanilla behaviour we can get without breaking our invariants, and what I opted for in this PR.)